### PR TITLE
draft review feedback

### DIFF
--- a/draft-huque-dnsop-ns-revalidation.xml
+++ b/draft-huque-dnsop-ns-revalidation.xml
@@ -4,18 +4,18 @@
      There has to be one entity for each item to be referenced.
      An alternate method (rfc include) is described in the references. -->
 
-<!ENTITY RFC1034 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1034.xml">
-<!ENTITY RFC1035 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.1035.xml">
-<!ENTITY RFC2181 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.2181.xml">
-<!ENTITY RFC3552 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3552.xml">
-<!ENTITY RFC4033 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4033.xml">
-<!ENTITY RFC4034 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4034.xml">
-<!ENTITY RFC4035 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.4035.xml">
-<!ENTITY I-D.narten-iana-considerations-rfc2434bis SYSTEM "http://xml.resource.org/public/rfc/bibxml3/reference.I-D.narten-iana-considerations-rfc2434bis.xml">
+<!ENTITY RFC1034 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.1034.xml">
+<!ENTITY RFC1035 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml">
+<!ENTITY RFC2181 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2181.xml">
+<!ENTITY RFC3552 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3552.xml">
+<!ENTITY RFC4033 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4033.xml">
+<!ENTITY RFC4034 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4034.xml">
+<!ENTITY RFC4035 SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.4035.xml">
+<!ENTITY I-D.narten-iana-considerations-rfc2434bis SYSTEM "http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.narten-iana-considerations-rfc2434bis.xml">
 <!ENTITY I-D.vixie-dnsext-resimprove SYSTEM
-"http://xml.resource.org/public/rfc/bibxml3/reference.I-D.vixie-dnsext-resimprove.xml">
+"http://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.vixie-dnsext-resimprove.xml">
 <!ENTITY I-D.wijngaards-dnsext-resolver-mitigation SYSTEM
-"https://xml.resource.org/public/rfc/bibxml3/reference.I-D.wijngaards-dnsext-resolver-side-mitigation.xml">
+"https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.wijngaards-dnsext-resolver-side-mitigation.xml">
 ]>
 
 <?xml-stylesheet type='text/xsl' href='rfc2629.xslt' ?>
@@ -215,7 +215,8 @@
 
       <t>
       <list style="symbols">
-
+	<!-- Ralph: I'm not sure I like the terms forwarding the triggering
+	     query, this sound very much pre-qname minimisation -->
 	<t>
 	   When a delegation response is received during iteration, a
 	   validation query should be sent in parallel with the forwarding of
@@ -231,29 +232,35 @@
 	   A validation query consists of a query for the child's apex NS
 	   RRset, sent to the newly discovered delegation's nameservers. Normal
 	   iterative logic applies to the processing of responses to validation
-	   queries, including storing the results in cache, propagating NXDOMAIN
-	   back to the triggering query, trying the next server on SERVFAIL or
-	   timeout, and so on.
+	   queries, including storing the results in cache, trying the next
+	   server on SERVFAIL or timeout, and so on. Positive answers to this
+	   validation query will be cached with an authoritative data ranking.
+	   Successive queries directed to the same zone will be directed to the
+	   nameservers listed in the child's apex, due to the ranking of this
+	   answer.
 	</t>
+
+	<!-- Ralph: fwiw, I'm ok with completely dropping the next items. Let's
+	     keep this simple. -->
 
 	<t>
 	   Some resolvers may choose to delay the response to the triggering
            query until both the forwarded query and the validation query have
            been answered. In practice, we expect many implementations may
            answer the forwarded query in advance of the validation query for
-           performance reasons. An additiotional reason is that there are number
+           performance reasons. An additional reason is that there are number
            of nameservers in the field that (incorrectly) do not answer explicit
            queries for NS records, and thus the revalidation logic may need to
            be applied lazily and opportunistically to deal with them.
 	</t>
 
 	<t>
-	   If there are no nameserver names in common between the child's
-	   apex NS RRset and the parent's delegation NS RRset, then the
-	   responses received from forwarding the triggering query to the
-	   parent's delegated nameservers should be discarded after validation,
-	   and this query should be forwarded again to the child's apex
-	   nameservers.
+	   If the resolver chooses to delay the response, and there are no
+	   nameserver names in common between the child's apex NS RRset and the
+	   parent's delegation NS RRset, then the responses received from
+	   forwarding the triggering query to the parent's delegated nameservers
+	   should be discarded after validation, and this query should be
+	   forwarded again to the child's apex nameservers.
 	</t>
 
       </list>
@@ -265,6 +272,10 @@
     <section title="Delegation Revalidation" anchor="revalidation">
 
       <t>
+        This documents proposes two mechanism to perform delegation
+	revalidation: an extensive and a simple mechanism. The extensive
+	mechanism:
+
       <list style="symbols">
 
 	<t>
@@ -311,20 +322,35 @@
 	   revocation of a zone by a parent zone administrator, and also
 	   conserves cache storage by deleting unreachable data.
 	</t>
-
-	<t>
-	   The text above describes a detailed algorithm for delegation
-	   revalidation. A simpler resolver implementation may choose
-	   alternative methods. For example, if the child NS TTL is lower
-           than the parent, revalidation will naturally occur at the
-           expiration of the child NS TTL, and no specific changes to the
-           resolution algorithm need to be implemented. If the child NS
-           TTL is larger than the parent, then the resolver will invoke
-           revalidation actions at the expiration of the parent NS TTL.
-	</t>
-
       </list>
-      </t>
+
+      The simple mechanism:
+      <list style="symbols">
+	<t>
+	   Limit the time to cache the child NS RRset to the TTL of the parent
+	   NS RRset. Revalidation will naturally occur at the expiration
+	   of the child NS TTL, and no specific changes to the resolution
+	   algorithm need to be implemented.
+	   <list style="symbols">
+	      <t>
+		      If the TTL of the child NS RRset is lower than the parent
+		      TTL, the parent NS RRset is the only NS RRset still
+		      available in cache after expiration of the child, and will
+		      be used to forward the triggering query to.  After this an
+		      validation query to upgrade the NS RRset credibility will
+		      be send.
+	      </t>
+	      <t>
+		      If the TTL of the child NS RRset is equal to or greater
+		      than the TTL of the parent NS RRset, neither of them will
+		      be used after the expiration of the record with the capped
+		      TTL and normal iteration will happen to resolve the
+		      record, including the query to upgrade the NS RRset
+		      credibility.
+	      </t>
+	   </list>
+	</t>
+      </list></t>
 
     </section>
 

--- a/draft-huque-dnsop-ns-revalidation.xml
+++ b/draft-huque-dnsop-ns-revalidation.xml
@@ -237,7 +237,9 @@
 	   validation query will be cached with an authoritative data ranking.
 	   Successive queries directed to the same zone will be directed to the
 	   nameservers listed in the child's apex, due to the ranking of this
-	   answer.
+	   answer. If the validation query fails the parent NS RRset will remain
+	   the one with the highest ranking and will be used for successive
+	   queries.
 	</t>
 
 	<!-- Ralph: fwiw, I'm ok with completely dropping the next items. Let's


### PR DESCRIPTION
- Change reference URLs to stop xml2rfc from complaining about mismatching TLS certs.
- Make clear that the last items of section 3 only applies when delaying the response.
- Split mechanisms in section 4 to make the easy way not just an afterthought.
- Add text about capping the child TTL in the easy mechanism.