### PR TITLE
refer to "minimal-responses" option in NSD

### DIFF
--- a/draft-ietf-dnsop-ns-revalidation.xml
+++ b/draft-ietf-dnsop-ns-revalidation.xml
@@ -163,7 +163,7 @@
       <t>
 	Increasingly, there is a trend towards minimizing unnecessary data
 	in DNS responses. Several popular DNS implementations default to such
-	a configuration (see "minimal-responses" in BIND and Unbound). So,
+	a configuration (see "minimal-responses" in BIND and NSD). So,
         they may never include the authoritative NS RRset in the Authority
         section of their responses.
       </t>


### PR DESCRIPTION
Unbound also has a minimal-responses option, so this is technically
not wrong. But this section is about the behaviour of authoritative
servers, not recursive resolvers.