### PR TITLE
23 dnsdir just a list of bullets

### DIFF
--- a/draft-ietf-dnsop-ns-revalidation.mkd
+++ b/draft-ietf-dnsop-ns-revalidation.mkd
@@ -175,31 +175,31 @@ Attacks exploiting lack of this revalidation have been described in {{GHOST1}}, 
 Upgrading NS RRset Credibility  {#upgrade-ns}
 ==============================
 
--   When a referral response is received during iteration, a validation query should be sent in parallel with the resolution of the triggering query, to the delegated nameservers for the newly discovered zone cut.
-    Note that validating resolvers today, when following a secure referral, already need to dispatch a query to the delegated nameservers for the DNSKEY RRset, so this validation query could be sent in parallel with that DNSKEY query.
+When a referral response is received during iteration, a validation query should be sent in parallel with the resolution of the triggering query, to the delegated nameservers for the newly discovered zone cut.
+Note that validating resolvers today, when following a secure referral, already need to dispatch a query to the delegated nameservers for the DNSKEY RRset, so this validation query could be sent in parallel with that DNSKEY query.
 
--   A validation query consists of a query for the child's apex NS RRset, sent to the newly discovered delegation's nameservers.
-    Normal iterative logic applies to the processing of responses to validation queries, including storing the results in cache, trying the next server on SERVFAIL or timeout, and so on.
-    Positive responses to this validation query will be cached with an authoritative data ranking.
-    Successive queries directed to the same zone will be directed to the nameservers listed in the child's apex, due to the ranking of this answer.
-    If the validation query fails, the parent NS RRset will remain the one with the highest ranking and will be used for successive queries.
+A validation query consists of a query for the child's apex NS RRset, sent to the newly discovered delegation's nameservers.
+Normal iterative logic applies to the processing of responses to validation queries, including storing the results in cache, trying the next server on SERVFAIL or timeout, and so on.
+Positive responses to this validation query will be cached with an authoritative data ranking.
+Successive queries directed to the same zone will be directed to the nameservers listed in the child's apex, due to the ranking of this answer.
+If the validation query fails, the parent NS RRset will remain the one with the highest ranking and will be used for successive queries.
 
--   Additional validation queries for the "glue" resource records of referral responses (if not already authoritatively present in cache) may be sent with the validation query for the NS RRset as well.
-    Positive responses will be cached authoritatively and replace the non authoritative "glue" entries.
-    Successive queries directed to the same zone will be directed to the authoritative values for the names of the NS RRset in the referral response.
+Additional validation queries for the "glue" resource records of referral responses (if not already authoritatively present in cache) may be sent with the validation query for the NS RRset as well.
+Positive responses will be cached authoritatively and replace the non authoritative "glue" entries.
+Successive queries directed to the same zone will be directed to the authoritative values for the names of the NS RRset in the referral response.
 
--   The names from the NS RRset from a validating NS query may differ from the names in NS RRset in the referral response.
-    Outstanding validation queries for "glue" that do not match names in the authoritative NS RRset be discarded, or they may be left running to completion.
-    Their result will no longer be used in queries for the zone.
-    Outstanding validation queries for "glue" that do match names in the authoritative NS RRset must be left running to completion.
-    They do not need to be re-queried after reception of the authoritative NS RRset (see [](#upgrade-addresses)).
+The names from the NS RRset from a validating NS query may differ from the names in NS RRset in the referral response.
+Outstanding validation queries for "glue" that do not match names in the authoritative NS RRset be discarded, or they may be left running to completion.
+Their result will no longer be used in queries for the zone.
+Outstanding validation queries for "glue" that do match names in the authoritative NS RRset must be left running to completion.
+They do not need to be re-queried after reception of the authoritative NS RRset (see [](#upgrade-addresses)).
 
--   Resolvers may choose to delay the response to the triggering query until both the triggering query and the validation query have been answered.
-    In practice, we expect many implementations may answer the triggering query in advance of the validation query for performance reasons.
-    An additional reason is that there are unfortunately a number of nameservers in the field that (incorrectly) fail to properly answer explicit queries for zone apex NS records, and thus the revalidation logic may need to be applied lazily and opportunistically to deal with them.
-    In cases where the delegated nameservers respond incorrectly to an NS query, the resolver should abandon this algorithm for the zone in question and fall back to using only the information from the parent's referral response.
+Resolvers may choose to delay the response to the triggering query until both the triggering query and the validation query have been answered.
+In practice, we expect many implementations may answer the triggering query in advance of the validation query for performance reasons.
+An additional reason is that there are unfortunately a number of nameservers in the field that (incorrectly) fail to properly answer explicit queries for zone apex NS records, and thus the revalidation logic may need to be applied lazily and opportunistically to deal with them.
+In cases where the delegated nameservers respond incorrectly to an NS query, the resolver should abandon this algorithm for the zone in question and fall back to using only the information from the parent's referral response.
 
--   If the resolver chooses to delay the response, and there are no nameserver names in common between the child's apex NS RRset and the parent's delegation NS RRset, then the responses received from forwarding the triggering query to the parent's delegated nameservers should be discarded after validation, and this query should be forwarded again to the child's apex nameservers.
+If the resolver chooses to delay the response, and there are no nameserver names in common between the child's apex NS RRset and the parent's delegation NS RRset, then the responses received from forwarding the triggering query to the parent's delegated nameservers should be discarded after validation, and this query should be forwarded again to the child's apex nameservers.
 
 Upgrading A and AAAA RRset Credibility  {#upgrade-addresses}
 ======================================


### PR DESCRIPTION
From https://datatracker.ietf.org/doc/review-ietf-dnsop-ns-revalidation-04-dnsdir-early-gieben-2023-07-30/
    
 > Small nit: section 3 currently is just a set of bullet points which looks a bit odd.