### PR TITLE
24 dnsdir use rfc2119 keywords

### DIFF
--- a/draft-ietf-dnsop-ns-revalidation.mkd
+++ b/draft-ietf-dnsop-ns-revalidation.mkd
@@ -140,6 +140,11 @@ The address records in the additional section from the referral response (as glu
 The authoritative answers from those queries should replace the cached non-authoritative A and AAAA RRsets.
 The second recommendation is to revalidate the delegation by re-querying the parent zone at the expiration of the TTL of the parent side NS RRset.
 
+Terminology
+-----------
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 {{?RFC2119}} {{?RFC8174}} when, and only when, they appear in all capitals, as shown here.
+
+
 Motivation                      {#motivation}
 ==========
 
@@ -175,7 +180,7 @@ Attacks exploiting lack of this revalidation have been described in {{GHOST1}}, 
 Upgrading NS RRset Credibility  {#upgrade-ns}
 ==============================
 
-When a referral response is received during iteration, a validation query should be sent in parallel with the resolution of the triggering query, to the delegated nameservers for the newly discovered zone cut.
+When a referral response is received during iteration, a validation query SHOULD be sent in parallel with the resolution of the triggering query, to the delegated nameservers for the newly discovered zone cut.
 Note that validating resolvers today, when following a secure referral, already need to dispatch a query to the delegated nameservers for the DNSKEY RRset, so this validation query could be sent in parallel with that DNSKEY query.
 
 A validation query consists of a query for the child's apex NS RRset, sent to the newly discovered delegation's nameservers.
@@ -189,17 +194,17 @@ Positive responses will be cached authoritatively and replace the non authoritat
 Successive queries directed to the same zone will be directed to the authoritative values for the names of the NS RRset in the referral response.
 
 The names from the NS RRset from a validating NS query may differ from the names in NS RRset in the referral response.
-Outstanding validation queries for "glue" that do not match names in the authoritative NS RRset be discarded, or they may be left running to completion.
+Outstanding validation queries for "glue" that do not match names in the authoritative NS RRset may be discarded, or they may be left running to completion.
 Their result will no longer be used in queries for the zone.
-Outstanding validation queries for "glue" that do match names in the authoritative NS RRset must be left running to completion.
+Outstanding validation queries for "glue" that do match names in the authoritative NS RRset MUST be left running to completion.
 They do not need to be re-queried after reception of the authoritative NS RRset (see [](#upgrade-addresses)).
 
 Resolvers may choose to delay the response to the triggering query until both the triggering query and the validation query have been answered.
 In practice, we expect many implementations may answer the triggering query in advance of the validation query for performance reasons.
 An additional reason is that there are unfortunately a number of nameservers in the field that (incorrectly) fail to properly answer explicit queries for zone apex NS records, and thus the revalidation logic may need to be applied lazily and opportunistically to deal with them.
-In cases where the delegated nameservers respond incorrectly to an NS query, the resolver should abandon this algorithm for the zone in question and fall back to using only the information from the parent's referral response.
+In cases where the delegated nameservers respond incorrectly to an NS query, the resolver SHOULD abandon this algorithm for the zone in question and fall back to using only the information from the parent's referral response.
 
-If the resolver chooses to delay the response, and there are no nameserver names in common between the child's apex NS RRset and the parent's delegation NS RRset, then the responses received from forwarding the triggering query to the parent's delegated nameservers should be discarded after validation, and this query should be forwarded again to the child's apex nameservers.
+If the resolver chooses to delay the response, and there are no nameserver names in common between the child's apex NS RRset and the parent's delegation NS RRset, then the responses received from forwarding the triggering query to the parent's delegated nameservers SHOULD be discarded after validation, and this query should be forwarded again to the child's apex nameservers.
 
 Upgrading A and AAAA RRset Credibility  {#upgrade-addresses}
 ======================================
@@ -230,16 +235,16 @@ If the response is not a referral or refers to a different zone than before, the
 If the response is a referral to the re-validation point but to a wholly novel NS RRset or a wholly novel DS RRset, then the authority for that zone has changed.
 For clarity, this includes transitions between empty and non-empty DS RRsets.
 
-If the shape of the delegation hierarchy or the authority for a zone has been found to change, then no currently cached data whose owner names are at or below that re-validation point can be used.
+If the shape of the delegation hierarchy or the authority for a zone has been found to change, then currently cached data whose owner names are at or below that re-validation point MUST NOT be used.
 Such non-use can be by directed garbage collection or lazy generational garbage collection or some other method befitting the architecture of the cache.
 What matters is that the cache behave as though this data was removed.
 
 Since re-validation can discover changes in the shape of the delegation hierarchy it is more efficient to re-validate from the top (root) downward (to the owner name) since an upper level re-validation may obviate lower level re-validations.
 What matters is that the supporting chain of delegations from the root to the owner name be demonstrably valid; further specifics are implementation details.
 
-Re-validation is triggered when delegation meta-data has been cached for a period at most exceeding the delegating NS or DS (if seen) RRset TTL.
-If the corresponding child zone's apex NS RRset TTL is smaller than the delegating NS RRset TTL, revalidation should happen at that interval instead.
-However, resolvers should impose a sensitive minimum TTL floor they are willing to endure to avoid potential computational DoS attacks inflicted by zones with very short TTLs.
+Re-validation MUST be triggered when delegation meta-data has been cached for a period at most exceeding the delegating NS or DS (if seen) RRset TTL.
+If the corresponding child zone's apex NS RRset TTL is smaller than the delegating NS RRset TTL, revalidation MUST happen at that interval instead.
+However, resolvers SHOULD impose a sensitive minimum TTL floor they are willing to endure to avoid potential computational DoS attacks inflicted by zones with very short TTLs.
 
 In normal operations this meta-data can be quickly re-validated with no further work.
 However, when re-delegation or take-down occurs, a re-validating cache will discover this within one delegation TTL period, allowing the rapid expulsion of old data from the cache.


### PR DESCRIPTION
From https://datatracker.ietf.org/doc/review-ietf-dnsop-ns-revalidation-04-dnsdir-early-gieben-2023-07-30/
    
> However when reading Section 3, I feel that this is an explanation of an algorithm and should use RFC 2119 keywords and be more precise.
