### PR TITLE
Only strict revalidation gives DNSSEC grade protection of infrastructure data

### DIFF
--- a/draft-ietf-dnsop-ns-revalidation.mkd
+++ b/draft-ietf-dnsop-ns-revalidation.mkd
@@ -266,7 +266,7 @@ In those cases no new validation queries need to be made.
 Strictly revalidating referral and authoritative NS RRset responses {#strict}
 -------------------------------------------------------------------
 Resolvers may choose to delay the response to a triggering query until it can be verified that the answer came from a name server listening on an authoritatively acquired address for an authoritatively acquired name.
-This would offer the most trustworthy responses with the least risk for forgery or eavesdropping, however without fallback to lower ranked NS RRsets and addresses, there is no failure mitigation and a failed NS RRset validation query will then lead to a hard failure to query the referred to child zone.
+This would offer the most trustworthy responses with the least risk for forgery or eavesdropping, however without fallback to lower ranked NS RRsets and addresses, there is no failure mitigation and a failed NS RRset validation query, due to a broken child NS RRset or to malfunctioning child zone's authoritative servers,  will then lead to a hard failure to query the referred to child zone.
 
 Delegation Revalidation         {#revalidation}
 =======================
@@ -320,7 +320,7 @@ Resolvers following referrals from a rogue name server, that do not revalidate t
 The higher up the DNS tree, the more impact such an attack has.
 An attacker controlling a rogue name server for the root has potentially complete control over the entire domain name space and can alter all unsigned parts undetected.
 
-Strictly revalidating referral and authoritative NS RRset responses (see {{strict}}), enables to defend against the above described attack with DNSSEC signed infrastructure RRsets.
+Strictly revalidating referral and authoritative NS RRset responses (see {{strict}}), enables the resolver to defend itself against the above described attack with DNSSEC signed infrastructure RRsets.
 Unlike cache poisoning defences that leverage increase entropy to protect the transaction, revalidation of NS RRsets and addresses also provides protection against on-path attacks.
 
 Since December 6, 2023, the root zone contains a DNSSEC signed cryptographic message digest {{RFC8976}}{{ROOT-ZONEMD}}, covering all root zone data.

--- a/draft-ietf-dnsop-ns-revalidation.mkd
+++ b/draft-ietf-dnsop-ns-revalidation.mkd
@@ -263,8 +263,10 @@ Otherwise, the addresses cannot be assumed to be complete or even authoritativel
 Note that there may be outstanding address validation queries for the names of the authoritative NS RRset (from referral address validation queries).
 In those cases no new validation queries need to be made.
 
+Strictly revalidating referral and authoritative NS RRset responses {#strict}
+-------------------------------------------------------------------
 Resolvers may choose to delay the response to a triggering query until it can be verified that the answer came from a name server listening on an authoritatively acquired address for an authoritatively acquired name.
-This would offer the most trustworthy responses with the least risk for forgery or eavesdropping.
+This would offer the most trustworthy responses with the least risk for forgery or eavesdropping, however without fallback to lower ranked NS RRsets and addresses, there is no failure mitigation and a failed NS RRset validation query will then lead to a hard failure to query the referred to child zone.
 
 Delegation Revalidation         {#revalidation}
 =======================
@@ -318,12 +320,12 @@ Resolvers following referrals from a rogue name server, that do not revalidate t
 The higher up the DNS tree, the more impact such an attack has.
 An attacker controlling a rogue name server for the root has potentially complete control over the entire domain name space and can alter all unsigned parts undetected.
 
-Revalidating referral and authoritative NS RRset responses enables to defend against the above described attack with DNSSEC signed infrastructure RRsets.
+Strictly revalidating referral and authoritative NS RRset responses (see {{strict}}), enables to defend against the above described attack with DNSSEC signed infrastructure RRsets.
 Unlike cache poisoning defences that leverage increase entropy to protect the transaction, revalidation of NS RRsets and addresses also provides protection against on-path attacks.
 
 Since December 6, 2023, the root zone contains a DNSSEC signed cryptographic message digest {{RFC8976}}{{ROOT-ZONEMD}}, covering all root zone data.
 This includes all non-authoritative data such as the A and AAAA RRsets for the IP addresses of the root server identifiers, as well as the NS RRsets and glue that make up the delegations.
-A root zone local to the resolver {{RFC8806}} with a verified and validated ZONEMD RRset, would provide protection similarly strong to revalidating the root and the top level domains.
+A root zone local to the resolver {{RFC8806}} with a verified and validated ZONEMD RRset, would provide protection similarly strong to strictly revalidating the root and the top level domains.
 
 Cache poisoning protection
 --------------------------


### PR DESCRIPTION
Only strict revalidation gives DNSSEC grade protection of infrastructure data
    
As mentioned by Ben Schwartz during the DNSOP WG session during the IETF 120
(see https://datatracker.ietf.org/meeting/120/materials/minutes-120-dnsop-02 )
