### PR TITLE
More precise implementation status for Unbound

### DIFF
--- a/draft-ietf-dnsop-ns-revalidation.mkd
+++ b/draft-ietf-dnsop-ns-revalidation.mkd
@@ -452,9 +452,11 @@ Implementation status           {#implementation-status}
 
 **Note to the RFC Editor**: please remove this entire appendix before publication.
 
-* The Unbound resolver software has delegation revalidation as described in this document implemented since version 1.1 (released August 29, 2008).
+* The Unbound resolver software has opportunistic revalidating of referral and authoritative NS RRset responses, as described in {{upgrade-ns}}, {{upgrade-addresses}} and {{opportunistic}} in this document, implemented since version 1.1 (released August 29, 2008).
   It is enabled with a configuration option `harden-referral-path: yes` which is disabled by default.
 
   "Redhat Enterprise Linux has been running Unbound with the `harden-referral-path:` option set to `yes` for years without problems", as mentioned by Paul Wouters during dnsop workgroup session at the IETF 119.
 * The Knot Resolver software revalidates the priming response as part of priming the root zone since version 1.5.1 (released December 12, 2017)
+
+* {{delegation-revalidation}} has been implemented in the Unbound resolver since version 1.4.17 (released May 24, 2012).
 


### PR DESCRIPTION
@shuque and @vixie, I have nuanced the implementation status section a bit to reflect what of our draft has been implemented precisely in Unbound.

Shall I merge that in version-10, render a xml from that and upload to datatracker?
